### PR TITLE
removed api key and set write-gcm to true

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,18 +14,10 @@ git clone this-git-repo roles/stackdriver
 Requirements
 ------------
 
-The agent must be configured with an API key, which you can create by signing
-into the [Stackdriver](http://www.stackdriver.com/) web console and looking for
-the "API Keys" tab in your account settings.
+The Google Cloud monitoring API must be enabled.
 
 Role Variables
 --------------
-
-You must provide the API key in your playbook:
-
-```
-stackdriver_api_key: "REQUIRED"
-```
 
 By default, no plugins are enabled, in which case the agent will only monitor
 certain system resources. (Moreover, all of the following variables are ignored

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -23,7 +23,6 @@
   local_action:
     module: stackdriver
     event: annotation
-    key: "{{ stackdriver_api_key }}"
     instance_id: "{{ stackdriver_host_id|default(ec2_id) }}"
     msg: |
       Stackdriver agent installed/updated on "{{ inventory_hostname }}".

--- a/tasks/Windows.yml
+++ b/tasks/Windows.yml
@@ -23,7 +23,7 @@
   when: not check.stat.exists
 
 - name: "[Windows] Install the Stackdriver agent."
-  raw: "{{ stackdriver_windows_installer }} /S /APIKEY={{ stackdriver_api_key }}"
+  raw: "{{ stackdriver_windows_installer }} /S"
   changed_when: True  # Default for raw appears to be False.
   when: not check.stat.exists
   notify: stackdriver updated

--- a/tasks/configure-settings.yml
+++ b/tasks/configure-settings.yml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ---
-- name: Configure the agent with the Stackdriver API key.
+- name: Configure the agent settings.
   template: src=stackdriver.sysconfig dest={{ stackdriver_sysconfig }} backup=yes
   notify:
     - restart collectd

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ---
-- include: configure-api-key.yml
+- include: configure-settings.yml
 
 - include: configure-plugins.yml
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -12,10 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ---
-- name: Check that the Stackdriver API key has been specified.
-  fail: msg="Please provide your Stackdriver API key in the variable stackdriver_api_key."
-  when: stackdriver_api_key is not defined or not stackdriver_api_key
-
 - name: Include OS-specific variables.
   include_vars: "{{ item }}"
   with_first_found:

--- a/templates/stackdriver.sysconfig
+++ b/templates/stackdriver.sysconfig
@@ -4,5 +4,5 @@ AUTOGENERATE_COLLECTD_CONFIG="yes"
 # url to a proxy for outbound https
 PROXY_URL=""
 
-# your stackdriver api key
-STACKDRIVER_API_KEY="{{ stackdriver_api_key }}"
+# use GCM
+DETECT_GCM="yes"


### PR DESCRIPTION
This partially fixes #15. Since I am not using EC2, the support for JSON credentials upload is not present (It could be useful for GCE in case the Monitoring API is disabled on a previously created instance). There is also no check for authorization as discussed in #16.
