### PR TITLE
chore: write-gcm option and enable/disable agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,11 @@ Legacy authentication method: provide stackdriver API key in your playbook:
 stackdriver_api_key: "API_KEY"
 ```
 
+You can choose to don't start stackdriver agent (and extractor if not using gcm) after installation or to stop it if it is running by setting stackdriver_enabled variable to false (the default value is `true`):
+```
+stackdriver_enabled: true
+```
+
 By default, no plugins are enabled, in which case the agent will only monitor
 certain system resources. (Moreover, all of the following variables are ignored
 when deploying to Windows.)

--- a/README.md
+++ b/README.md
@@ -134,7 +134,9 @@ stackdriver_nginx_password: ""
 
 When connceting to PostgreSQL the plugin will connect using a local Unix
 socket. To connect via TCP/IP, specify a host name of `127.0.0.1`. The
-default port is 5432.
+default port is 5432. If a port is provided without a host name, the
+pluggin will use Unix domain socket to connect to the database. The port 
+is incorporated into the path: `/var/run/postgresql/.s.PGSQL.5432`.
 
 You need to provide the user name and password of the user who will run
 the `\dt` command for each database specified. By default the user is

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -16,7 +16,10 @@
 # Please refer to ../README.md for more information about configuring the
 # various plugins.
 
-### stackdriver agent installation options
+### stackdriver agent options
+
+# define if stackdriver agent must be running or not (more info in the readme)
+stackdriver_enabled: true
 
 stackdriver_use_gcm: true
 

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -14,11 +14,13 @@
 ---
 - name: restart collectd
   service: name={{ stackdriver_collectd_service }} state=restarted
+  when: stackdriver_enabled
 
-- name: restart extractor if not using gcm
+- name: restart extractor
   service:
     name: "{{ stackdriver_extractor_service }}"
     state: "{% if stackdriver_use_gcm %}stopped{% else %}restarted{% endif %}"
+  when: stackdriver_enabled
 
 - name: stackdriver updated
   sudo: no
@@ -35,5 +37,5 @@
       No plugins.
       {% endif %}
   changed_when: False
-  when: stackdriver_events_enabled and (
-    stackdriver_host_id is defined or ec2_id is defined)
+  when: stackdriver_enabled and stackdriver_events_enabled
+        and (stackdriver_host_id is defined or ec2_id is defined)

--- a/tasks/configure-agent.yml
+++ b/tasks/configure-agent.yml
@@ -16,5 +16,5 @@
   template: src=stackdriver.sysconfig dest={{ stackdriver_sysconfig }} backup=yes
   notify:
     - restart collectd
-    - restart extractor if not using gcm
+    - restart extractor
     - stackdriver updated

--- a/tasks/configure-plugins.yml
+++ b/tasks/configure-plugins.yml
@@ -20,7 +20,7 @@
     src: "{{ item }}.conf"
     dest: "{{ stackdriver_collectd_config_dir }}/{{ item }}.conf"
     validate: "{{ stackdriver_collectd_binary }} -tC %s"
-  with_items: stackdriver_enabled_plugins
+  with_items: '{{ stackdriver_enabled_plugins }}'
   when: item != ""
   notify:
     - restart collectd
@@ -33,7 +33,7 @@
 
 - name: Remove unmanaged files if requested.
   file: path={{ stackdriver_collectd_config_dir }}/{{ item }} state=absent
-  with_items: contents.stdout_lines
+  with_items: '{{ contents.stdout_lines }}'
   when: >
     stackdriver_remove_unmanaged and (
       not (item.endswith('.conf') and item != '.conf') or

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -16,15 +16,18 @@
 
 - include: configure-plugins.yml
 
-- name: Ensure collectd is running.
-  service: name={{ stackdriver_collectd_service }} state=started enabled=yes
+- name: "Ensure collectd is {% if not stackdriver_enabled %}not {% endif %}running."
+  service:
+    name: "{{ stackdriver_collectd_service }}"
+    state: "{% if stackdriver_enabled %}started{% else %}stopped{% endif %}"
+    enabled: "{% if stackdriver_enabled %}yes{% else %}no{% endif %}"
 
-- name: Ensure extractor is running if not using gcm
+- name: "Ensure extractor is {% if not (stackdriver_enabled and not stackdriver_use_gcm) %}not {% endif %}running."
   service:
     name: "{{ stackdriver_extractor_service }}"
-    state: "{% if stackdriver_use_gcm %}stopped{% else %}started{% endif %}"
-    enabled: "{% if stackdriver_use_gcm %}no{% else %}yes{% endif %}"
+    state: "{% if stackdriver_use_gcm or not stackdriver_enabled %}stopped{% else %}started{% endif %}"
+    enabled: "{% if stackdriver_use_gcm or not stackdriver_enabled %}no{% else %}yes{% endif %}"
 
 - name: Determine the Stackdriver host ID for reporting if not using gcm
   action: stackdriver_facts
-  when: not stackdriver_use_gcm
+  when: not stackdriver_use_gcm and stackdriver_enabled

--- a/tasks/diagnostics.yml
+++ b/tasks/diagnostics.yml
@@ -70,6 +70,8 @@
     psql --username {{ stackdriver_postgresql_user }}
     {% if stackdriver_postgresql_host is defined %}
     --host {{ stackdriver_postgresql_host }}
+    {% endif %}
+    {% if stackdriver_postgresql_port is defined %}
     --port {{ stackdriver_postgresql_port }}
     {% endif %}
     --dbname {{ item }}

--- a/templates/postgresql.conf
+++ b/templates/postgresql.conf
@@ -4,6 +4,8 @@ LoadPlugin postgresql
   <Database "{{ database }}">
 {% if stackdriver_postgresql_host is defined %}
     Host "{{ stackdriver_postgresql_host }}"
+{% endif %}
+{% if stackdriver_postgresql_port is defined %}
     Port "{{ stackdriver_postgresql_port }}"
 {% endif %}
     User "{{ stackdriver_postgresql_user }}"

--- a/templates/stackdriver.sysconfig
+++ b/templates/stackdriver.sysconfig
@@ -5,6 +5,6 @@ AUTOGENERATE_COLLECTD_CONFIG="yes"
 PROXY_URL=""
 
 # your stackdriver api key if not using gcm
-STACKDRIVER_API_KEY="{% if stackdriver_api_key is defined %}stackdriver_api_key{% endif %}"
+STACKDRIVER_API_KEY="{% if stackdriver_api_key is defined %}{{ stackdriver_api_key }}{% endif %}"
 
 DETECT_GCM="{% if stackdriver_use_gcm %}yes{% else %}no{% endif %}"


### PR DESCRIPTION
As #23, this also partially fixes #15, but without removing api key support because some users still need it. This branch also add the possibility to disable/enable the stackdriver agent.