### PR TITLE
Fix variable precendence bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@ Ansible Role for Cloud Ops
 This Ansible role installs the Cloud Ops agents.
 
 Install this directory in your roles path (usually in a `roles` directory
-alongside your playbook) under the name `cloud_ops`:
+alongside your playbook) under the name `google_cloud_ops_agents`:
 
 ```
-git clone <this-git-repo> roles/cloud_ops
+git clone <this-git-repo> roles/google_cloud_ops_agents
 ```
 
 Requirements

--- a/README.md
+++ b/README.md
@@ -1,6 +1,3 @@
-Warning: This repo is under active development and not yet suitable for use.
-============================================================================
-
 Ansible Role for Cloud Ops
 ==========================
 

--- a/README.md
+++ b/README.md
@@ -6,16 +6,14 @@ This Ansible role installs the Cloud Ops agents.
 Install this directory in your roles path (usually in a `roles` directory
 alongside your playbook) under the name `google_cloud_ops_agents`:
 
-```
-git clone <this-git-repo> roles/google_cloud_ops_agents
-```
+``` git clone <this-git-repo> roles/google_cloud_ops_agents ```
 
 Requirements
 ------------
 
-Permissions to Google Cloud API. If running on an old Compute Engine instance or
-Compute Engine instances created without the default credentials, then you must
-complete the following steps
+Permissions to the Google Cloud API. If you are running an old Compute Engine
+instance or Compute Engine instances created without the default credentials,
+then you must complete the following steps
 https://cloud.google.com/monitoring/agent/authorization#before_you_begin.
 
 Role Variables
@@ -76,15 +74,21 @@ Example Playbook
 ```
 # Example
 - hosts: all
-  become: yes
+  become: true
   roles:
-    - role: cloud_ops
+    - role: google_cloud_ops_agents
       vars:
         agent_type: monitoring
         package_state: present
         version: latest
-        config_file_local: collectd.conf
+        main_config_file: collectd.conf
         additional_config_dir: plugins/
+
+    - role: google_cloud_ops_agents
+      vars:
+        agent_type: logging
+        package_state: present
+        version: 1.*.*
 ```
 
 License

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,8 +1,8 @@
 ---
-agent_type: ""
+agent_type: ''
 package_state: present
 version: latest
 # Local path to the config file to copy onto the remote server. Can be absolute or relative.
-main_config_file: ""
+main_config_file: ''
 # Local path to the additonal config directory whose contents will be copied onto the remote server. Can be absolute or relative.
-additional_config_dir: ""
+additional_config_dir: ''

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -4,10 +4,3 @@
     name: "{{ vars[agent_type + '_service_name'] }}"
     state: restarted
   when: package_state == 'present' and not ansible_check_mode
-
-# vars['*'] syntax is needed when referencing variables with names containing `-`
-- name: restart google-cloud-ops agent
-  service:
-    name: "{{ vars['google-cloud-ops_service_name'] }}"
-    state: restarted
-  when: package_state == 'present' and not ansible_check_mode

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,6 +1,7 @@
 galaxy_info:
+  role_name: google_cloud_ops_agents
   author: Ryan Moriarty
-  description: Install the Cloud Ops Monitoring Agent
+  description: Install the Google Cloud Ops Agents
   company: Google
   license: Apache-2.0
   min_ansible_version: 2.1
@@ -26,4 +27,13 @@ galaxy_info:
         - 15
   galaxy_tags:
     - monitoring
+    - logging
+    - ops-agent
+    - google
+    - google-cloud
+    - collectd
+    - fluentd
+    - fluent-bit
+    - open-telemetry
+    - agent
 dependencies: []

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,16 +9,11 @@
     that: package_state in ['present', 'absent']
     msg: "Received invalid package state: '{{ package_state }}'. The Cloud Ops Ansible role supports the following package states: 'present' and 'absent'."
 
-- when: agent_type == 'ops-agent'
-  block:
-    - name: Ensure no additional config directory was specified
-      assert:
-        that: not additional_config_dir
-        msg: 'The ops agent does not support additional configurations. additional_config_dir must be empty when agent_type is ops-agent.'
-
-    - name: Set ops-agent agent_type to its fully qualified name
-      set_fact:
-        agent_type: google-cloud-ops
+- name: Ensure no additional config directory was specified
+  assert:
+    that: not additional_config_dir
+    msg: 'The ops agent does not support additional configurations. additional_config_dir must be empty when agent_type is ops-agent.'
+  when: agent_type == 'ops-agent'
 
 - name: Create temp directory
   tempfile:
@@ -31,8 +26,8 @@
 
 - name: Download script
   get_url:
-    url: "https://dl.google.com/cloudagents/add-{{ agent_type }}-agent-repo.sh"
-    dest: "{{ tempfolder.path }}/add-{{ agent_type }}-agent-repo.sh"
+    url: "https://dl.google.com/cloudagents/add-{{ 'google-cloud-ops' if agent_type == 'ops-agent' else agent_type }}-agent-repo.sh"
+    dest: "{{ tempfolder.path }}/add-{{ 'google-cloud-ops' if agent_type == 'ops-agent' else agent_type }}-agent-repo.sh"
     mode: 0755
   check_mode: false
   changed_when: false
@@ -40,7 +35,7 @@
 - name: Add repo and install agent or remove repo and uninstall agent
   command:
     chdir: "{{ tempfolder.path }}"
-    cmd: "bash add-{{ agent_type }}-agent-repo.sh {{ '--also-install' if package_state == 'present' else '--uninstall --remove-repo' }} --version={{ version }} {{ '--dry-run' if ansible_check_mode else '' }}"
+    cmd: "bash add-{{ 'google-cloud-ops' if agent_type == 'ops-agent' else agent_type }}-agent-repo.sh {{ '--also-install' if package_state == 'present' else '--uninstall --remove-repo' }} --version={{ version }} {{ '--dry-run' if ansible_check_mode else '' }}"
   environment:
     REPO_CODENAME: "{{ ansible_distribution_release }}"
   register: result

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -18,7 +18,7 @@
 
     - name: Set ops-agent agent_type to its fully qualified name
       set_fact:
-        agent_type: 'google-cloud-ops'
+        agent_type: google-cloud-ops
 
 - name: Create temp directory
   tempfile:
@@ -26,7 +26,7 @@
     state: directory
     suffix: cloud_ops_shell_scripts
   register: tempfolder
-  check_mode: no
+  check_mode: false
   changed_when: false
 
 - name: Download script
@@ -34,7 +34,7 @@
     url: "https://dl.google.com/cloudagents/add-{{ agent_type }}-agent-repo.sh"
     dest: "{{ tempfolder.path }}/add-{{ agent_type }}-agent-repo.sh"
     mode: 0755
-  check_mode: no
+  check_mode: false
   changed_when: false
 
 - name: Add repo and install agent or remove repo and uninstall agent
@@ -44,7 +44,7 @@
   environment:
     REPO_CODENAME: "{{ ansible_distribution_release }}"
   register: result
-  check_mode: no
+  check_mode: false
   changed_when: "'No changes made.' not in result.stdout_lines"
   notify: "restart {{ agent_type }} agent"
 
@@ -54,7 +54,7 @@
       copy:
         src: "{{ main_config_file }}"
         dest: "{{ vars[agent_type + '_config_path'] }}"
-        force: yes
+        force: true
         mode: 0644
         validate: "{{ vars[agent_type + '_validation_cmd'] }}"
       when: main_config_file
@@ -64,7 +64,7 @@
       copy:
         src: "{{ item }}"
         dest: "{{ vars[agent_type + '_plugins_path'] }}"
-        force: yes
+        force: true
         mode: 0644
         validate: "{{ vars[agent_type + '_validation_cmd'] }}"
       with_fileglob:
@@ -76,5 +76,5 @@
   file:
     path: "{{ tempfolder.path }}"
     state: absent
-  check_mode: no
+  check_mode: false
   changed_when: false

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,17 +9,17 @@
     that: package_state in ['present', 'absent']
     msg: "Received invalid package state: '{{ package_state }}'. The Cloud Ops Ansible role supports the following package states: 'present' and 'absent'."
 
-- name: Ensure no additional config directory was specified
+- name: Ensure no additional config directory was specified when configuring the ops-agent
   assert:
     that: not additional_config_dir
-    msg: 'The ops agent does not support additional configurations. additional_config_dir must be empty when agent_type is ops-agent.'
+    msg: "The ops agent does not support additional configurations. additional_config_dir must be empty when the agent_type is 'ops-agent'."
   when: agent_type == 'ops-agent'
 
 - name: Create temp directory
   tempfile:
     path: /tmp
     state: directory
-    suffix: cloud_ops_shell_scripts
+    suffix: _cloud_ops_shell_scripts
   register: tempfolder
   check_mode: false
   changed_when: false

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -2,4 +2,4 @@
 - hosts: localhost
   remote_user: root
   roles:
-    - ../google-cloud-ops-agents-ansible
+    - ../stackdriver-ansible-role

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -2,4 +2,4 @@
 - hosts: localhost
   remote_user: root
   roles:
-    - ../stackdriver-ansible-role
+    - ../google_cloud_ops_agents

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -2,4 +2,4 @@
 - hosts: localhost
   remote_user: root
   roles:
-    - ../google-cloud-ops-agent
+    - ../google-cloud-ops-agents-ansible

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -2,4 +2,4 @@
 - hosts: localhost
   remote_user: root
   roles:
-    - ../google_cloud_ops_agents
+    - ../google-cloud-ops-agent

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -11,4 +11,4 @@ logging_validation_cmd: '/usr/sbin/google-fluentd -c %s --dry-run'
 
 google-cloud-ops_service_name: google-cloud-ops-agent.target
 google-cloud-ops_config_path: /etc/google-cloud-ops-agent/config.yaml
-google-cloud-ops_validation_cmd: "/opt/google-cloud-ops-agent/subagents/collectd/sbin/collectd -tC %s"
+google-cloud-ops_validation_cmd: '/opt/google-cloud-ops-agent/subagents/collectd/sbin/collectd -tC %s'

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -9,6 +9,6 @@ logging_config_path: /etc/google-fluentd/google-fluentd.conf
 logging_plugins_path: /etc/google-fluentd/plugin/
 logging_validation_cmd: '/usr/sbin/google-fluentd -c %s --dry-run'
 
-google-cloud-ops_service_name: google-cloud-ops-agent.target
-google-cloud-ops_config_path: /etc/google-cloud-ops-agent/config.yaml
-google-cloud-ops_validation_cmd: '/opt/google-cloud-ops-agent/subagents/collectd/sbin/collectd -tC %s'
+ops-agent_service_name: google-cloud-ops-agent.target
+ops-agent_config_path: /etc/google-cloud-ops-agent/config.yaml
+ops-agent_validation_cmd: '/opt/google-cloud-ops-agent/subagents/collectd/sbin/collectd -tC %s'


### PR DESCRIPTION
Using set_fact to change ops-agent to google-cloud-ops might have a lower variable precedence that the `agent_type` with which the user invoked the role (which would cause set_fact to be a no-op).

Add role name to meta/main.yml and add galaxy tags.

Convert all truthy values to true/false.