### PR TITLE
Set correct min ansible version

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -6,7 +6,7 @@ galaxy_info:
   description: Install the Google Cloud Ops Agents
   company: Google
   license: Apache-2.0
-  min_ansible_version: 2.1
+  min_ansible_version: 2.9
   platforms:
     - name: Debian
       versions:

--- a/tasks/linux.yml
+++ b/tasks/linux.yml
@@ -38,7 +38,7 @@
         force: true
         mode: 0644
         validate: "{{ vars[agent_type + '_validation_cmd'] }}"
-      when: main_config_file
+      when: main_config_file | length > 0
       notify: "restart {{ agent_type }} agent"
 
     - name: Copy additional configs onto the remote machine
@@ -50,7 +50,7 @@
         validate: "{{ vars[agent_type + '_validation_cmd'] }}"
       with_fileglob:
         - "{{ additional_config_dir }}/*.conf"
-      when: additional_config_dir
+      when: additional_config_dir | length > 0
       notify: "restart {{ agent_type }} agent"
 
 - name: Remove temp directory

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -18,7 +18,7 @@
 
 - name: Ensure no additional config directory was specified when configuring the ops-agent
   assert:
-    that: not additional_config_dir
+    that: additional_config_dir | length == 0
     msg: "The ops agent does not support additional configurations. additional_config_dir must be empty when the agent_type is 'ops-agent'."
   when: agent_type == 'ops-agent'
 

--- a/tasks/windows.yml
+++ b/tasks/windows.yml
@@ -38,7 +38,7 @@
         src: "{{ main_config_file }}"
         dest: 'C:\Program Files\Google\Cloud Operations\Ops Agent\config\config.yaml'
         force: true
-      when: main_config_file
+      when: main_config_file | length > 0
       notify: "restart ops-agent agent windows"
 
 - name: Remove temp directory


### PR DESCRIPTION
Set the correct min ansible version in meta/main. 
Using string variables directly as truthy values wasn't supported until ansible v3.0, so to be more backward compatible use length tests instead.