### PR TITLE
Add a retry policy for the script installation/uninstallation task.

### DIFF
--- a/tasks/linux.yml
+++ b/tasks/linux.yml
@@ -24,6 +24,8 @@
       '--uninstall --remove-repo' }} --version={{ version }} {{ '--dry-run' if ansible_check_mode else '' }}
   environment:
     REPO_CODENAME: "{{ ansible_distribution_release }}"
+  retries: 5
+  delay: 10
   register: result
   check_mode: false
   changed_when: "'No changes made.' not in result.stdout_lines"

--- a/tasks/windows.yml
+++ b/tasks/windows.yml
@@ -26,6 +26,8 @@
     {{ '-WhatIf' if ansible_check_mode else ''}}
   args:
     chdir: "{{ tempfolder.path }}"
+  retries: 5
+  delay: 10
   register: result
   check_mode: false
   changed_when: "'No changes made.' not in result.stdout_lines"


### PR DESCRIPTION
Transient errors related to the shell scripts can cause this to fail. Therefore it's best to have a retry policy.