### PR TITLE
Support Ops Agent 2.0.0

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,7 +1,7 @@
 ---
 - name: "restart {{ agent_type }} agent"
   service:
-    name: "{{ vars[agent_type + '_service_name'] }}"
+    name: "{{ service_name }}"
     state: restarted
   when: package_state == 'present' and not ansible_check_mode
 

--- a/molecule/resources/playbooks/verify_linux.yml
+++ b/molecule/resources/playbooks/verify_linux.yml
@@ -1,4 +1,19 @@
 ---
+- name: Set Service Name
+  set_fact:
+    service_name: "google-cloud-ops-agent{{'.target' if lookup('env', 'VERSION').split('.')[0] == '1' }}"
+  when: agent_type == 'ops-agent'
+
+- name: Set Service Name
+  set_fact:
+    service_name: stackdriver-agent
+  when: agent_type == 'monitoring'
+
+- name: Set Service Name
+  set_fact:
+    service_name: google-fluentd
+  when: agent_type == 'logging'
+
 - name: Include vars
   include_vars:
     file: "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') }}/vars/main.yml"
@@ -15,13 +30,39 @@
 
 - name: Ensure the agent is running
   service:
-    name: "{{ vars[agent_type + '_service_name'] }}"
+    name: "{{ service_name }}"
     state: started
   register: result
+  when: (agent_type != 'ops-agent') or (agent_type == 'ops-agent' and lookup('env', 'VERSION').split('.')[0] == '1')
 
 - name: Assert the agent was already running
   assert:
     that: result.changed == false
+  when: (agent_type != 'ops-agent')
+
+- name: Ensure the ops agent fluentbit agent is running
+  service:
+    name: "{{ service_name }}-fluent-bit.service"
+    state: started
+  register: result
+  when: (agent_type == 'ops-agent' and lookup('env', 'VERSION').split('.')[0] != '1')
+
+- name: Assert the ops agent fluentbit agent was already running
+  assert:
+    that: result.changed == false
+  when: (agent_type == 'ops-agent' and lookup('env', 'VERSION').split('.')[0] != '1')
+
+- name: Ensure the ops agent opentelemetry-collector is running
+  service:
+    name: "{{ service_name }}-opentelemetry-collector.service"
+    state: started
+  register: result
+  when: (agent_type == 'ops-agent' and lookup('env', 'VERSION').split('.')[0] != '1')
+
+- name: Assert the ops agent opentelemetry-collector was already running
+  assert:
+    that: result.changed == false
+  when: (agent_type == 'ops-agent' and lookup('env', 'VERSION').split('.')[0] != '1')
 
 - when: main_config_file | length > 0
   block:

--- a/molecule/resources/playbooks/verify_linux.yml
+++ b/molecule/resources/playbooks/verify_linux.yml
@@ -33,36 +33,10 @@
     name: "{{ service_name }}"
     state: started
   register: result
-  when: (agent_type != 'ops-agent') or (agent_type == 'ops-agent' and lookup('env', 'VERSION').split('.')[0] == '1')
 
 - name: Assert the agent was already running
   assert:
     that: result.changed == false
-  when: (agent_type != 'ops-agent')
-
-- name: Ensure the ops agent fluentbit agent is running
-  service:
-    name: "{{ service_name }}-fluent-bit.service"
-    state: started
-  register: result
-  when: (agent_type == 'ops-agent' and lookup('env', 'VERSION').split('.')[0] != '1')
-
-- name: Assert the ops agent fluentbit agent was already running
-  assert:
-    that: result.changed == false
-  when: (agent_type == 'ops-agent' and lookup('env', 'VERSION').split('.')[0] != '1')
-
-- name: Ensure the ops agent opentelemetry-collector is running
-  service:
-    name: "{{ service_name }}-opentelemetry-collector.service"
-    state: started
-  register: result
-  when: (agent_type == 'ops-agent' and lookup('env', 'VERSION').split('.')[0] != '1')
-
-- name: Assert the ops agent opentelemetry-collector was already running
-  assert:
-    that: result.changed == false
-  when: (agent_type == 'ops-agent' and lookup('env', 'VERSION').split('.')[0] != '1')
 
 - when: main_config_file | length > 0
   block:

--- a/tasks/linux.yml
+++ b/tasks/linux.yml
@@ -1,4 +1,19 @@
 ---
+- name: Set Service Name
+  set_fact:
+    service_name: "{{ ops_agent_service_name }}{{'.target' if version.split('.')[0] == '1' }}"
+  when: agent_type == 'ops-agent'
+
+- name: Set Service Name
+  set_fact:
+    service_name: "{{ monitoring_service_name }}"
+  when: agent_type == 'monitoring'
+
+- name: Set Service Name
+  set_fact:
+    service_name: "{{ logging_service_name }}"
+  when: agent_type == 'logging'
+
 - name: Create temp directory
   tempfile:
     path: /tmp

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -9,9 +9,9 @@ logging_config_path: /etc/google-fluentd/google-fluentd.conf
 logging_plugins_path: /etc/google-fluentd/plugin/
 logging_validation_cmd: '/usr/sbin/google-fluentd -c %s --dry-run'
 
-ops-agent_service_name: google-cloud-ops-agent.target
+ops_agent_service_name: google-cloud-ops-agent
 ops-agent_config_path: /etc/google-cloud-ops-agent/config.yaml
-ops-agent_validation_cmd: '/opt/google-cloud-ops-agent/subagents/collectd/sbin/collectd -tC %s'
+ops-agent_validation_cmd: '/opt/google-cloud-ops-agent/subagents/fluent-bit/bin/fluent-bit -c %s'
 
 windows_logging_service_name: StackdriverLogging
 windows_logging_config_path: 'C:\Program Files (x86)\Stackdriver\LoggingAgent\fluent.conf'

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -11,7 +11,7 @@ logging_validation_cmd: '/usr/sbin/google-fluentd -c %s --dry-run'
 
 ops_agent_service_name: google-cloud-ops-agent
 ops-agent_config_path: /etc/google-cloud-ops-agent/config.yaml
-ops-agent_validation_cmd: '/opt/google-cloud-ops-agent/subagents/fluent-bit/bin/fluent-bit -c %s'
+ops-agent_validation_cmd: '/opt/google-cloud-ops-agent/libexec/google_cloud_ops_agent_engine -in /etc/google-cloud-ops-agent/config.yaml'
 
 windows_logging_service_name: StackdriverLogging
 windows_logging_config_path: 'C:\Program Files (x86)\Stackdriver\LoggingAgent\fluent.conf'


### PR DESCRIPTION
- Changed how service names are handled
  - A fact is used to set `service_name`, based on the service name variables in `vars/`
  - Renamed `ops_agent_service_name` to `ops-agent_service_name`, Ansible complains about naming convention when referencing the variable while setting a fact or during condition evaluation.
   - The new ops agent does not have `.target` as a suffix for its service name, this is handled conditionally depending on if major version `1` or not.
- Updated ops-agent_validation_cmd to target fluentbit as collectd has been replaced

Tested on Linux against ops agent 1.0.4 and 2.0.0 and 2.0.1. (note that 2.0.0 will fail its service test case, see [this PR](https://github.com/GoogleCloudPlatform/ops-agent/pull/132) for the solution)
```bash
molecule create -s ops-agent-test
molecule cleanup -s ops-agent-test 
molecule converge -s ops-agent-test
molecule idempotence -s ops-agent-test 
molecule verify -s ops-agent-test
```

I do not like the redundant use of the "Service Name" fact, however, it was tricky to get conditional variable naming to work wirth the ops agent, which has two options (`google-ops-agent` and `google-ops-agent.target`).

I have not tested the following as my CI environment will not support them
- Windows 
- new ops-agent_validation_cmd command, which validates the ops agent config instead of the sub agent config

Resolves https://github.com/GoogleCloudPlatform/google-cloud-ops-agents-ansible/issues/64
