### PR TITLE
fix typo

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,5 +1,5 @@
 ---
-- name: Validate Operating Systen
+- name: Validate Operating System
   assert:
     that: >
       ansible_os_family == 'Windows' or ansible_distribution in ['Debian', 'Ubuntu', 'RedHat', 'CentOS', 'Amazon', 'SLES', 'openSUSE', 'SuSE', 'SLES_SAP',


### PR DESCRIPTION
I have found a typo in the `tasks/main.yml`. So I have fixed that.

* wrong: `Systen`
* correct: `System`