### PR TITLE
Rename role to comply with Ansible Galaxy conventions.

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,6 +1,6 @@
 ---
 galaxy_info:
-  role_name: google_cloud_ops_agents
+  role_name: google-cloud-ops-agents-ansible
   namespace: google_cloud_platform
   author: Ryan Moriarty
   description: Install the Google Cloud Ops Agents


### PR DESCRIPTION
Rename from `google_cloud_ops_agents` to`google-cloud-ops-agents-ansible`

Addresses feedback from b/193553018.