### PR TITLE
Stop testing on ubuntu-2010 (Groovy)

### DIFF
--- a/molecule/logging-test/molecule.yml
+++ b/molecule/logging-test/molecule.yml
@@ -65,13 +65,6 @@ platforms:
     groups:
       - linux
       - ubuntu
-  - name: "ansible-ubuntu-2010-${MOLECULE_SCENARIO_NAME}"
-    image_family: projects/ubuntu-os-cloud/global/images/family/ubuntu-2010
-    machine_type: e2-medium
-    size_gb: 40
-    groups:
-      - linux
-      - ubuntu
   - name: "ansible-debian-9-${MOLECULE_SCENARIO_NAME}"
     image_family: projects/debian-cloud/global/images/family/debian-9
     machine_type: e2-medium

--- a/molecule/monitoring-test/molecule.yml
+++ b/molecule/monitoring-test/molecule.yml
@@ -65,13 +65,6 @@ platforms:
     groups:
       - linux
       - ubuntu
-  - name: "ansible-ubuntu-2010-${MOLECULE_SCENARIO_NAME}"
-    image_family: projects/ubuntu-os-cloud/global/images/family/ubuntu-2010
-    machine_type: e2-medium
-    size_gb: 40
-    groups:
-      - linux
-      - ubuntu
   - name: "ansible-debian-9-${MOLECULE_SCENARIO_NAME}"
     image_family: projects/debian-cloud/global/images/family/debian-9
     machine_type: e2-medium


### PR DESCRIPTION
Groovy is now deprecated and presubmits are failing due to this.

Deprecation was checked with the following command:
gcloud compute images list --show-deprecated | grep -E 'ubuntu-(minimal-)?2010'