### PR TITLE
Support Ops Agent 2.*

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,7 +1,7 @@
 ---
 - name: "restart {{ agent_type }} agent"
   service:
-    name: "{{ vars[agent_type + '_service_name'] }}"
+    name: "{{ vars[agent_type + '_service_name'] }}{{ '.target' if agent_type == 'ops-agent' and version.split('.')[0] == '1' else '' }}"
     state: restarted
   when: package_state == 'present' and not ansible_check_mode
 

--- a/molecule/resources/playbooks/verify_linux.yml
+++ b/molecule/resources/playbooks/verify_linux.yml
@@ -15,7 +15,7 @@
 
 - name: Ensure the agent is running
   service:
-    name: "{{ vars[agent_type + '_service_name'] }}"
+    name: "{{ vars[agent_type + '_service_name'] }}{{ '.target' if agent_type == 'ops-agent' and lookup('env', 'VERSION').split('.')[0] == '1' else '' }}"
     state: started
   register: result
 

--- a/tasks/linux.yml
+++ b/tasks/linux.yml
@@ -41,7 +41,16 @@
         force: true
         mode: 0644
         validate: "{{ vars[agent_type + '_validation_cmd'] }}"
-      when: main_config_file | length > 0
+      when: main_config_file | length > 0 and agent_type != 'ops-agent'
+      notify: "restart {{ agent_type }} agent"
+
+    - name: Copy main config file onto the remote machine
+      copy:
+        src: "{{ main_config_file }}"
+        dest: "{{ vars[agent_type + '_config_path'] }}"
+        force: true
+        mode: 0644
+      when: main_config_file | length > 0 and agent_type == 'ops-agent'
       notify: "restart {{ agent_type }} agent"
 
     - name: Copy additional configs onto the remote machine

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -9,9 +9,8 @@ logging_config_path: /etc/google-fluentd/google-fluentd.conf
 logging_plugins_path: /etc/google-fluentd/plugin/
 logging_validation_cmd: '/usr/sbin/google-fluentd -c %s --dry-run'
 
-ops-agent_service_name: google-cloud-ops-agent.target
+ops-agent_service_name: google-cloud-ops-agent
 ops-agent_config_path: /etc/google-cloud-ops-agent/config.yaml
-ops-agent_validation_cmd: '/opt/google-cloud-ops-agent/subagents/collectd/sbin/collectd -tC %s'
 
 windows_logging_service_name: StackdriverLogging
 windows_logging_config_path: 'C:\Program Files (x86)\Stackdriver\LoggingAgent\fluent.conf'


### PR DESCRIPTION
Conditionally add '.target' to the service name if the user is installing version 1.* of the ops agent.

Remove validation step installing the ops-agent with custom config.

Fixes #64, #73.