### PR TITLE
Change the recommend ansible-galaxy installation command.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,15 +8,15 @@ Install the Role
 
 * [Recommended] To use Ansible Galaxy to handle dependencies, use this command
   to install:
-  
-  ```$ ansible-galaxy install git+https://github.com/GoogleCloudPlatform/google-cloud-ops-agents-ansible.git```
+
+  ```ansible-galaxy install googlecloudplatform.google_cloud_ops_agents```
 
 * To use GitHub submodules to handle dependencies, install this directory in
   your roles path (usually in a roles directory alongside your playbook) under
-  the name `google_cloud_ops_agents`:
-  
-  ```git clone <this-git-repo> roles/google_cloud_ops_agents```
-  
+  the name `googlecloudplatform.google_cloud_ops_agents`:
+
+  ```git clone <this-git-repo> roles/googlecloudplatform.google_cloud_ops_agents```
+
 Requirements
 ------------
 
@@ -85,11 +85,11 @@ Example Playbooks
 - hosts: all
   become: true
   roles:
-    - role: google_cloud_ops_agents
+    - role: googlecloudplatform.google_cloud_ops_agents
       vars:
         agent_type: monitoring
 
-    - role: google_cloud_ops_agents
+    - role: googlecloudplatform.google_cloud_ops_agents
       vars:
         agent_type: logging
 ```
@@ -98,14 +98,14 @@ Example Playbooks
 - hosts: all
   become: true
   roles:
-    - role: google_cloud_ops_agents
+    - role: googlecloudplatform.google_cloud_ops_agents
       vars:
         agent_type: monitoring
         version: latest
         main_config_file: monitoring_agent.conf
         additional_config_dir: monitoring_agent_dir/
 
-    - role: google_cloud_ops_agents
+    - role: googlecloudplatform.google_cloud_ops_agents
       vars:
         agent_type: logging
         version: 1.*.*
@@ -117,7 +117,7 @@ Example Playbooks
 - hosts: all
   become: true
   roles:
-    - role: google_cloud_ops_agents
+    - role: googlecloudplatform.google_cloud_ops_agents
       vars:
         agent_type: ops-agent
 ```
@@ -126,7 +126,7 @@ Example Playbooks
 - hosts: all
   become: true
   roles:
-    - role: google_cloud_ops_agents
+    - role: googlecloudplatform.google_cloud_ops_agents
       vars:
         agent_type: ops-agent
         version: 1.0.1


### PR DESCRIPTION
Change ansible-galaxy install command to the one listed on the repo's galaxy page: https://galaxy.ansible.com/GoogleCloudPlatform/google_cloud_ops_agents

Adjust sample playbooks accordingly.

Fixes b/193553018.