### PR TITLE
Add the language markup to YAML code blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ applications](https://cloud.google.com/monitoring/agent/plugins).
 Example Playbooks
 ----------------
 
-```
+```yaml
 # Installing the Monitoring and Logging agents
 - hosts: all
   become: true
@@ -96,7 +96,8 @@ Example Playbooks
       vars:
         agent_type: logging
 ```
-```
+
+```yaml
 # Installing the Monitoring and Logging agents with custom configurations
 - hosts: all
   become: true
@@ -115,7 +116,8 @@ Example Playbooks
         main_config_file: logging_agent.conf
         additional_config_dir: logging_agent_dir/
 ```
-```
+
+```yaml
 # Installing the Ops-Agent
 - hosts: all
   become: true
@@ -124,7 +126,8 @@ Example Playbooks
       vars:
         agent_type: ops-agent
 ```
-```
+
+```yaml
 # Installing the Ops-Agent with custom configuration
 - hosts: all
   become: true


### PR DESCRIPTION
Hello 🙂 

This PR adds the <code>```yaml</code> language markup to colorize the code snippets for better readability.

## Screenshot

### Before

<img width="903" alt="Screen Shot 2021-10-11 at 14 53 01" src="https://user-images.githubusercontent.com/1425259/136739718-9274aad4-c167-4bc3-b92b-75a30ce9bb3b.png">

### After

<img width="1052" alt="Screen Shot 2021-10-11 at 14 48 16" src="https://user-images.githubusercontent.com/1425259/136739458-73e9d9a3-71ff-4575-a5c8-3e020447be66.png">
