### PR TITLE
updated copy command to template command

### DIFF
--- a/tasks/linux.yml
+++ b/tasks/linux.yml
@@ -35,7 +35,7 @@
 - when: package_state == 'present'
   block:
     - name: Copy main config file onto the remote machine
-      copy:
+      template:
         src: "{{ main_config_file }}"
         dest: "{{ vars[agent_type + '_config_path'] }}"
         force: true
@@ -45,7 +45,7 @@
       notify: "restart {{ agent_type }} agent"
 
     - name: Copy main config file onto the remote machine
-      copy:
+      template:
         src: "{{ main_config_file }}"
         dest: "{{ vars[agent_type + '_config_path'] }}"
         force: true
@@ -54,7 +54,7 @@
       notify: "restart {{ agent_type }} agent"
 
     - name: Copy additional configs onto the remote machine
-      copy:
+      template:
         src: "{{ item }}"
         dest: "{{ vars[agent_type + '_plugins_path'] }}"
         force: true


### PR DESCRIPTION
Updated copy command to template command so that google-cloud-ops-agent config files can be dynamically generated.
For eg: using GCE instance hostname in the ops agent receiver configuration