### PR TITLE
Remove centos-8 as it is now deprecated

### DIFF
--- a/molecule/logging-test/molecule.yml
+++ b/molecule/logging-test/molecule.yml
@@ -23,13 +23,6 @@ platforms:
     groups:
       - linux
       - centos
-  - name: "ansible-centos-8-${MOLECULE_SCENARIO_NAME}"
-    image_family: projects/centos-cloud/global/images/family/centos-8
-    machine_type: e2-medium
-    size_gb: 40
-    groups:
-      - linux
-      - centos
   - name: "ansible-rocky-8-${MOLECULE_SCENARIO_NAME}"
     image_family: projects/rocky-linux-cloud/global/images/family/rocky-linux-8
     machine_type: e2-medium

--- a/molecule/monitoring-test/molecule.yml
+++ b/molecule/monitoring-test/molecule.yml
@@ -23,13 +23,6 @@ platforms:
     groups:
       - linux
       - centos
-  - name: "ansible-centos-8-${MOLECULE_SCENARIO_NAME}"
-    image_family: projects/centos-cloud/global/images/family/centos-8
-    machine_type: e2-medium
-    size_gb: 40
-    groups:
-      - linux
-      - centos
   - name: "ansible-rocky-8-${MOLECULE_SCENARIO_NAME}"
     image_family: projects/rocky-linux-cloud/global/images/family/rocky-linux-8
     machine_type: e2-medium

--- a/molecule/ops-agent-test/molecule.yml
+++ b/molecule/ops-agent-test/molecule.yml
@@ -23,13 +23,6 @@ platforms:
     groups:
       - linux
       - centos
-  - name: "ansible-centos-8-${MOLECULE_SCENARIO_NAME}"
-    image_family: projects/centos-cloud/global/images/family/centos-8
-    machine_type: e2-medium
-    size_gb: 40
-    groups:
-      - linux
-      - centos
   - name: "ansible-rocky-8-${MOLECULE_SCENARIO_NAME}"
     image_family: projects/rocky-linux-cloud/global/images/family/rocky-linux-8
     machine_type: e2-medium


### PR DESCRIPTION
Let's see if the tests (stackdriver_agents/testing/consumer/ansible/piper_presubmit_ops_agent and friends) get back to green with this change. It certainly can't hurt... right??