### PR TITLE
Remove debian-9 as it is now deprecated

### DIFF
--- a/.yamllint
+++ b/.yamllint
@@ -22,6 +22,6 @@ rules:
     level: error
   key-duplicates: enable
   line-length:
-    max: 160
+    max: 170
   new-lines:
     type: unix

--- a/molecule/logging-test/molecule.yml
+++ b/molecule/logging-test/molecule.yml
@@ -58,13 +58,6 @@ platforms:
     groups:
       - linux
       - ubuntu
-  - name: "ansible-debian-9-${MOLECULE_SCENARIO_NAME}"
-    image_family: projects/debian-cloud/global/images/family/debian-9
-    machine_type: e2-medium
-    size_gb: 40
-    groups:
-      - linux
-      - debian
   - name: "ansible-debian-10-${MOLECULE_SCENARIO_NAME}"
     image_family: projects/debian-cloud/global/images/family/debian-10
     machine_type: e2-medium

--- a/molecule/monitoring-test/molecule.yml
+++ b/molecule/monitoring-test/molecule.yml
@@ -58,13 +58,6 @@ platforms:
     groups:
       - linux
       - ubuntu
-  - name: "ansible-debian-9-${MOLECULE_SCENARIO_NAME}"
-    image_family: projects/debian-cloud/global/images/family/debian-9
-    machine_type: e2-medium
-    size_gb: 40
-    groups:
-      - linux
-      - debian
   - name: "ansible-debian-10-${MOLECULE_SCENARIO_NAME}"
     image_family: projects/debian-cloud/global/images/family/debian-10
     machine_type: e2-medium

--- a/molecule/ops-agent-test/molecule.yml
+++ b/molecule/ops-agent-test/molecule.yml
@@ -58,13 +58,6 @@ platforms:
     groups:
       - linux
       - ubuntu
-  - name: "ansible-debian-9-${MOLECULE_SCENARIO_NAME}"
-    image_family: projects/debian-cloud/global/images/family/debian-9
-    machine_type: e2-medium
-    size_gb: 40
-    groups:
-      - linux
-      - debian
   - name: "ansible-debian-10-${MOLECULE_SCENARIO_NAME}"
     image_family: projects/debian-cloud/global/images/family/debian-10
     machine_type: e2-medium


### PR DESCRIPTION
Should fix errors like `The resource 'projects/debian-cloud/global/images/family/debian-9' was not found`.